### PR TITLE
Fix bold formatting for Kinetix paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
                   <br>
                   Michael Matthews*, Michael Beukman*, <b>Chris Lu</b>, Jakob Foerster<br>
                   *Equal Contribution<br>
-                  ICLR 2025 (Oral)<br>
+                  <b>ICLR 2025 (Oral)</b><br>
                   <div class="paper" id="kinetix">
                     <a href="https://arxiv.org/abs/2410.23208">arXiv</a> |
                     <a href="https://kinetix-env.github.io/">blog</a> |


### PR DESCRIPTION
## Summary
- bold the ICLR 2025 conference info for the Kinetix paper

## Testing
- `git grep -n "ICLR 2025"`

------
https://chatgpt.com/codex/tasks/task_e_68536c82c500833180f849a0ba6cbe77